### PR TITLE
feat: 사용자 정보 수정 api를 개발 했어요.

### DIFF
--- a/api/src/main/kotlin/adapter/in/web/controller/member/MyInfoController.kt
+++ b/api/src/main/kotlin/adapter/in/web/controller/member/MyInfoController.kt
@@ -1,10 +1,17 @@
 package org.team_alilm.adapter.`in`.web.controller.member
 
 import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.tags.Tag
+import jakarta.validation.Valid
+import jakarta.validation.constraints.Email
+import jakarta.validation.constraints.NotNull
+import jakarta.validation.constraints.Pattern
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 import org.team_alilm.application.port.`in`.use_case.MyInfoUseCase
@@ -37,4 +44,44 @@ class MyInfoController(
         val nickname: String,
         val email: String
     )
+
+    @Operation(
+        summary = "내 정보 수정 API",
+        description = """
+            내 정보를 수정합니다.
+            사용자의 닉네임을 수정하는 api 입니다.
+    """)
+    @PostMapping
+    fun updateMyInfo(
+        @AuthenticationPrincipal
+        customMemberDetails: CustomMemberDetails,
+
+        @Valid @RequestBody
+        request: UpdateMyInfoRequest
+    ) : ResponseEntity<Unit> {
+        val command = MyInfoUseCase.UpdateMyInfoCommand(customMemberDetails.member, request.nickname, request.email)
+        myInfoUseCase.updateMyInfo(command)
+
+        return ResponseEntity.ok().build()
+    }
+
+    data class UpdateMyInfoRequest(
+        @Email
+        @field:NotNull(message = "email은 필수입니다.")
+        @field:Schema(
+            example = "team.alilms@gmail.com",
+            description = "이메일",
+            required = true,
+        )
+        val email: String,
+
+        @field:NotNull(message = "nickName은 필수입니다.")
+        @field:Pattern(
+            // 한국어, 영어, 숫자 만 가능하고 1~12자로 제한
+            regexp = "^[a-zA-Z0-9가-힣]{1,12}\$",
+            message = "닉네임은 4~12자의 영문 대소문자, 숫자로 이루어져야 합니다."
+        )
+        val nickname: String,
+    )
+
 }

--- a/api/src/main/kotlin/global/filter/LoggingFilter.kt
+++ b/api/src/main/kotlin/global/filter/LoggingFilter.kt
@@ -3,8 +3,6 @@ package org.team_alilm.global.filter
 import jakarta.servlet.FilterChain
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
-import org.springframework.security.core.context.SecurityContextHolder
-import org.springframework.security.core.userdetails.UserDetails
 import org.springframework.web.filter.OncePerRequestFilter
 import org.springframework.web.util.ContentCachingRequestWrapper
 import org.springframework.web.util.ContentCachingResponseWrapper

--- a/core/src/main/kotlin/application/port/in/use_case/MyInfoUseCase.kt
+++ b/core/src/main/kotlin/application/port/in/use_case/MyInfoUseCase.kt
@@ -14,4 +14,12 @@ interface MyInfoUseCase {
         val nickname: String,
         val email: String
     )
+
+    fun updateMyInfo(command: UpdateMyInfoCommand)
+
+    data class UpdateMyInfoCommand(
+        val member: Member,
+        val email: String,
+        val nickname: String
+    )
 }

--- a/core/src/main/kotlin/application/service/MyInfoService.kt
+++ b/core/src/main/kotlin/application/service/MyInfoService.kt
@@ -3,22 +3,27 @@ package org.team_alilm.application.service
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import org.team_alilm.application.port.`in`.use_case.MyInfoUseCase
-import org.team_alilm.global.error.NotFoundMemberException
+import org.team_alilm.application.port.out.AddMemberPort
 
 @Service
-@Transactional
+@Transactional(readOnly = true)
 class MyInfoService(
-    val loadMemberPort: org.team_alilm.application.port.out.LoadMemberPort
+    private val addMemberPort: AddMemberPort
 ) : MyInfoUseCase {
 
-    override fun myInfo(command: org.team_alilm.application.port.`in`.use_case.MyInfoUseCase.MyInfoCommand): org.team_alilm.application.port.`in`.use_case.MyInfoUseCase.MyInfoResult {
-        val member = loadMemberPort.loadMember(command.member.id!!.value)
-            ?: throw NotFoundMemberException()
-
-        return org.team_alilm.application.port.`in`.use_case.MyInfoUseCase.MyInfoResult(
-            nickname = member.nickname,
-            email = member.email
+    override fun myInfo(command: MyInfoUseCase.MyInfoCommand): MyInfoUseCase.MyInfoResult {
+        return MyInfoUseCase.MyInfoResult(
+            nickname = command.member.nickname,
+            email = command.member.email
         )
+    }
+
+    @Transactional
+    override fun updateMyInfo(command: MyInfoUseCase.UpdateMyInfoCommand) {
+        val member = command.member
+        member.changeInfo(command.nickname, command.email)
+
+        addMemberPort.addMember(member)
     }
 
 }

--- a/core/src/main/kotlin/application/service/OauthLoginMemberService.kt
+++ b/core/src/main/kotlin/application/service/OauthLoginMemberService.kt
@@ -22,9 +22,7 @@ class OauthLoginMemberService(
 
     @Transactional
     override fun loginMember(provider: Member.Provider, providerId: String, attributes: Map<String, Any>): Member {
-        return loadMemberPort.loadMember(provider, providerId)?.let {
-            updateMember(it, attributes)
-        } ?: run {
+        return loadMemberPort.loadMember(provider, providerId)?: run {
             val newMember = saveMember(attributes)
             saveMemberRoleMapping(newMember)
             newMember
@@ -50,9 +48,4 @@ class OauthLoginMemberService(
         addMemberRoleMappingPort.addMemberRoleMapping(member, role)
     }
 
-    private fun updateMember(member: Member, attributes: Map<String, Any>): Member {
-        val newNickname = attributes["nickname"].toString()
-        member.update(newNickname)
-        return member
-    }
 }

--- a/core/src/main/kotlin/domain/Member.kt
+++ b/core/src/main/kotlin/domain/Member.kt
@@ -4,7 +4,7 @@ class Member(
     val id: MemberId? = null,
     val provider: Provider,
     val providerId: Long,
-    val email: String,
+    var email: String,
     var nickname: String,
     ) {
 
@@ -13,8 +13,9 @@ class Member(
         require(nickname.isNotBlank()) { "nickname must not be blank" }
     }
 
-    fun update(newNickname: String) {
+    fun changeInfo(newNickname: String, newEmail: String) {
         this.nickname = newNickname
+        this.email = newEmail
     }
 
     data class MemberId(val value: Long)

--- a/security/src/main/kotlin/SecurityApplication.kt
+++ b/security/src/main/kotlin/SecurityApplication.kt
@@ -3,7 +3,7 @@ package org.team_alilm
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
 
-@SpringBootApplication
+@SpringBootApplication(scanBasePackages = ["org.team_alilm.*"])
 class SecurityApplication
 
 fun main(args: Array<String>) {

--- a/security/src/main/kotlin/config/SecurityConfig.kt
+++ b/security/src/main/kotlin/config/SecurityConfig.kt
@@ -1,6 +1,5 @@
 package org.team_alilm.config
 
-import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.autoconfigure.security.servlet.PathRequest
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration


### PR DESCRIPTION
- loggingFilter에서 사용하지 않는 의존성 제거
- member email 변경 가능한 var 변수로 변경
- controller, service 제작
- ouath2 login 시 사용자 정보 변경 없도록 수정

## 작업 내용

<!-- 작업한 사항을 간략하게 적어주세요 -->

## 사용자 영향
정상적인 token이 있는 사용자는 자신의 nickname, email을 수정할 수 있어요.
<!-- 사용자에게 어떤 변화를 일으킬 수 있을까요? -->